### PR TITLE
Added opencv lib path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(orbslam3)
 
+set(OpenCV_LIBS /usr/local/lib)
 # You should set the PYTHONPATH to your own python site-packages path
-set(ENV{PYTHONPATH} "/opt/ros/foxy/lib/python3.8/site-packages/")
+set(ENV{PYTHONPATH} "/opt/ros/humble/lib/python3.10/site-packages")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 
@@ -28,6 +29,7 @@ include_directories(
   include
   ${ORB_SLAM3_ROOT_DIR}/include
   ${ORB_SLAM3_ROOT_DIR}/include/CameraModels
+  ${ORB_SLAM3_ROOT_DIR}/Thirdparty/Sophus
 )
 
 link_directories(
@@ -51,7 +53,7 @@ add_executable(stereo
   src/stereo/stereo-slam-node.cpp
 )
 ament_target_dependencies(stereo rclcpp sensor_msgs cv_bridge message_filters
-ORB_SLAM3 Pangolin)
+	ORB_SLAM3 Pangolin )
 
 add_executable(stereo-inertial
   src/stereo-inertial/stereo-inertial.cpp
@@ -59,8 +61,13 @@ add_executable(stereo-inertial
 )
 ament_target_dependencies(stereo-inertial rclcpp sensor_msgs cv_bridge ORB_SLAM3 Pangolin)
 
-install(TARGETS mono rgbd stereo stereo-inertial
-  DESTINATION lib/${PROJECT_NAME})
+target_link_libraries(mono ${OpenCV_LIBS})
+target_link_libraries(rgbd ${OpenCV_LIBS})
+target_link_libraries(stereo ${OpenCV_LIBS})
+target_link_libraries(stereo-inertial ${OpenCV_LIBS})
+
+
+install(TARGETS mono rgbd stereo stereo-inertial DESTINATION lib/${PROJECT_NAME})
 
 # Install launch files.
 #install(DIRECTORY launch config vocabulary

--- a/CMakeModules/FindORB_SLAM3.cmake
+++ b/CMakeModules/FindORB_SLAM3.cmake
@@ -5,7 +5,7 @@
 #
 # To help the search ORB_SLAM3_ROOT_DIR environment variable as the path to ORB_SLAM3 root folder
 #  e.g. `set( ORB_SLAM3_ROOT_DIR=~/ORB_SLAM3) `
-set(ORB_SLAM3_ROOT_DIR "~/Install/ORB_SLAM/ORB_SLAM3")
+set(ORB_SLAM3_ROOT_DIR "~/Coding/ORB_SLAM3")
 
 # message(${ORB_SLAM3_ROOT_DIR})
 # message(${ORB_SLAM3_ROOT_DIR}/include)


### PR DESCRIPTION
When trying to build I had this errors
```
/usr/bin/ld: CMakeFiles/stereo.dir/src/stereo/stereo-slam-node.cpp.o: undefined reference to symbol '_ZN2cv23initUndistortRectifyMapERKNS_11_InputArrayES2_S2_S2_NS_5Size_IiEEiRKNS_12_OutputArrayES7_'
/usr/bin/ld: /usr/local/lib/libopencv_calib3d.so.4.5: error adding symbols: DSO missing from command line
```

So I included the opencv library path to correct it