### PR TITLE
fixed opencv cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,41 +23,47 @@ find_package(message_filters REQUIRED)
 find_package(Sophus REQUIRED)
 find_package(Pangolin REQUIRED)
 find_package(ORB_SLAM3 REQUIRED)
+find_package(OpenCV REQUIRED)  # Find OpenCV
 
 include_directories(
   include
   ${ORB_SLAM3_ROOT_DIR}/include
   ${ORB_SLAM3_ROOT_DIR}/include/CameraModels
+  ${OpenCV_INCLUDE_DIRS}  # Include OpenCV headers
 )
 
 link_directories(
   include
 )
 
+# Add OpenCV to the linking of the executable
 add_executable(mono
   src/monocular/mono.cpp
   src/monocular/monocular-slam-node.cpp
 )
 ament_target_dependencies(mono rclcpp sensor_msgs cv_bridge ORB_SLAM3 Pangolin)
+target_link_libraries(mono ${OpenCV_LIBS})
 
 add_executable(rgbd
   src/rgbd/rgbd.cpp
   src/rgbd/rgbd-slam-node.cpp
 )
 ament_target_dependencies(rgbd rclcpp sensor_msgs cv_bridge message_filters ORB_SLAM3 Pangolin)
+target_link_libraries(rgbd ${OpenCV_LIBS})
 
 add_executable(stereo
   src/stereo/stereo.cpp
   src/stereo/stereo-slam-node.cpp
 )
-ament_target_dependencies(stereo rclcpp sensor_msgs cv_bridge message_filters
-ORB_SLAM3 Pangolin)
+ament_target_dependencies(stereo rclcpp sensor_msgs cv_bridge message_filters ORB_SLAM3 Pangolin)
+target_link_libraries(stereo ${OpenCV_LIBS})
 
 add_executable(stereo-inertial
   src/stereo-inertial/stereo-inertial.cpp
   src/stereo-inertial/stereo-inertial-node.cpp
 )
 ament_target_dependencies(stereo-inertial rclcpp sensor_msgs cv_bridge ORB_SLAM3 Pangolin)
+target_link_libraries(stereo-inertial ${OpenCV_LIBS})
 
 install(TARGETS mono rgbd stereo stereo-inertial
   DESTINATION lib/${PROJECT_NAME})
@@ -67,4 +73,3 @@ install(TARGETS mono rgbd stereo stereo-inertial
 #  DESTINATION share/${PROJECT_NAME}/)
 
 ament_package()
-


### PR DESCRIPTION
CMake linker cant find OpenCV libraries sometimes

/usr/bin/ld: CMakeFiles/stereo-inertial.dir/src/stereo-inertial/stereo-inertial-node.cpp.o: undefined reference to symbol '_ZN2cv23initUndistortRectifyMapERKNS_11_InputArrayES2_S2_S2_NS_5Size_IiEEiRKNS_12_OutputArrayES7_'
/usr/bin/ld: /lib/x86_64-linux-gnu/libopencv_calib3d.so.4.5d: error adding symbols: DSO missing from command line

This should fix it by manually linking